### PR TITLE
Add planned ID_SELF_DISCONNECTION to differentiate between connection…

### DIFF
--- a/Source/include/slikenet/MessageIdentifiers.h
+++ b/Source/include/slikenet/MessageIdentifiers.h
@@ -125,6 +125,8 @@ enum DefaultMessageIDTypes
 	/// RakPeer - The system specified in Packet::systemAddress has disconnected from us.  For the client, this would mean the
 	/// server has shutdown. 
 	ID_DISCONNECTION_NOTIFICATION,
+	/// RakPeer - we initiated disconnect
+	ID_SELF_DISCONNECTION,
 	/// RakPeer - Reliable packets cannot be delivered to the system specified in Packet::systemAddress.  The connection to that
 	/// system has been closed. 
 	ID_CONNECTION_LOST,

--- a/Source/src/RakPeer.cpp
+++ b/Source/src/RakPeer.cpp
@@ -5877,6 +5877,8 @@ bool RakPeer::RunUpdateCycle(BitStream &updateBitStream )
 						packet->data[ 0 ] = ID_CONNECTION_ATTEMPT_FAILED; // Attempted a connection and couldn't
 					else if (remoteSystem->connectMode==RemoteSystemStruct::CONNECTED)
 						packet->data[ 0 ] = ID_CONNECTION_LOST; // DeadConnection
+					else if (remoteSystem->connectMode == RemoteSystemStruct::DISCONNECT_ASAP_SILENTLY || remoteSystem->connectMode == RemoteSystemStruct::DISCONNECT_ASAP)
+						packet->data[0] = ID_SELF_DISCONNECTION; // UserInitiated
 					else
 						packet->data[ 0 ] = ID_DISCONNECTION_NOTIFICATION; // DeadConnection
 
@@ -6392,6 +6394,9 @@ void RakPeer::CallPluginCallbacks(DataStructures::List<PluginInterface2*> &plugi
 	{
 		switch (packet->data[0])
 		{
+		case ID_SELF_DISCONNECTION:
+			pluginList[i]->OnClosedConnection(packet->systemAddress, packet->guid, LCR_CLOSED_BY_USER);
+			break;
 		case ID_DISCONNECTION_NOTIFICATION:
 			pluginList[i]->OnClosedConnection(packet->systemAddress, packet->guid, LCR_DISCONNECTION_NOTIFICATION);
 			break;


### PR DESCRIPTION
There was an old TODO record in RakPeer.c on 5865:

> // TODO - RakNet 4.0 - Return a different message identifier for DISCONNECT_ASAP_SILENTLY and DISCONNECT_ASAP than for DISCONNECT_ON_NO_ACK
> 				// The first two mean we called CloseConnection(), the last means the other system sent us ID_DISCONNECTION_NOTIFICATION

With this modification the library can differentiate between connection lost and self initiated disconnection (when we call CloseConnection()).