### PR TITLE
Use small letters in include(s) for easier cross-compilation

### DIFF
--- a/Source/include/slikenet/WindowsIncludes.h
+++ b/Source/include/slikenet/WindowsIncludes.h
@@ -24,8 +24,8 @@
 #include <winsock2.h>
 #include <windows.h>
 #include <ws2tcpip.h>
-#include <IPHlpApi.h> // used for GetAdaptersAddresses()
-#pragma comment(lib, "IPHLPAPI.lib") // used for GetAdaptersAddresses()
+#include <iphlpapi.h> // used for GetAdaptersAddresses()
+#pragma comment(lib, "iphlpapi.lib") // used for GetAdaptersAddresses()
 
 // Must always include Winsock2.h before windows.h
 // or else:


### PR DESCRIPTION
Hi!

Recently i've pulled the project and tried to compile under linux targeting windows.
Unfortunately i had to make one little change to run the mingw cross-compiler.

I suggest adding this small change to the main project, simply to run cross-compilation
without any errors (as we all know, Linux is case-sensitive).

NOTE: (decapitalization in #pragma comment part isn't necessary)