### PR TITLE
Fixed memory leak in UDPForwarder.cpp

### DIFF
--- a/Source/src/UDPForwarder.cpp
+++ b/Source/src/UDPForwarder.cpp
@@ -519,6 +519,9 @@ void UDPForwarder::UpdateUDPForwarder(void)
 					}
 				}
 
+				// Release address info after we have used it
+				freeaddrinfo(servinfo);
+
 				if (fe->socket==INVALID_SOCKET)
 					sfos.result=UDPFORWARDER_BIND_FAILED;
 				else


### PR DESCRIPTION
Memory leak is caused by addrinfo struct being assigned to when creating UDPForwarder (using IPv6) but not being freed after use.

Leak is relatively slow and can take a while to grow but when dealing with large traffic it is definitely noticeable. Leak was originally found within the original RakNet code base and still exists here so I thought I would submit the fix that I used that resolves the leak.